### PR TITLE
Issue #17 Support Carbon v2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "nesbot/carbon": "~1.18",
+        "nesbot/carbon": "~1.18|^2.0",
         "psr/http-message": "^1.0",
         "moneyphp/money": "^3.0",
         "guzzlehttp/psr7": "^1.4"


### PR DESCRIPTION
No functional changes will be needed for this. The main difference with
Carbon 2.x is that it is immutable. We get around that for 1.x by
cloning when we want to add or subtract, and that will work the same
even for an immutable object.